### PR TITLE
Remove "self" positional argument from loadFromHandle function.

### DIFF
--- a/pyirt/util/dao.py
+++ b/pyirt/util/dao.py
@@ -23,7 +23,7 @@ def loadFromTuples(data):
 
     return user_ids, item_ids, ans_tags
 
-def loadFromHandle(self, fp, sep=','):
+def loadFromHandle(fp, sep=','):
     # Default format is comma separated files,
     # Only int is allowed within the environment
     user_ids = []


### PR DESCRIPTION
The function loadFromHandle had a first positional argument called "self" which caused a fatal error.  Fixed by removing the "self" positional argument.