### PR TITLE
KeyError fix in localDAO

### DIFF
--- a/pyirt/dao.py
+++ b/pyirt/dao.py
@@ -147,7 +147,14 @@ class localDAO(object):
 
     def get_map(self, item_idx, ans_key_list):
         # NOTE: return empty list for invalid ans key
-        return [self.database.item2user_map[str(ans_key)][item_idx] for ans_key in ans_key_list]
+        results = []
+        for ans_key in ans_key_list:
+            try:
+                results.append(self.database.item2user_map[str(ans_key)][item_idx])
+            except KeyError:
+                results.append([])
+        # return [self.database.item2user_map[str(ans_key)][item_idx] for ans_key in ans_key_list]
+        return results
 
     def close_conn(self):
         pass


### PR DESCRIPTION
I believe this fixes [Issue 13](https://github.com/17zuoye/pyirt/issues/13) which I also ran into. The KeyError exception is not caught in localDAO get_map when item_idx does not exist for a given ans_key. This can happen when no users provided ans_key for item_idx. There was a previous comment to return an empty list in these cases which I have done and this resolves the error for me and provides sensible results. This is not caught in the localDAO test as the test data contains only a single question id.